### PR TITLE
feat: added 'similar collections' to graasp explore

### DIFF
--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -5,6 +5,7 @@ import { Divider } from '@material-ui/core';
 import Summary from './Summary';
 import Items from './Items';
 import Comments from './Comments';
+import SimilarCollections from './SimilarCollections';
 import {
   comments,
   contributors,
@@ -15,6 +16,7 @@ import {
   likes,
   name,
   rating,
+  similarCollections,
   views,
 } from '../../data/sample';
 
@@ -48,6 +50,8 @@ function Collection() {
       <Items items={items} />
       <Divider className={classes.divider} />
       <Comments comments={comments} />
+      <Divider className={classes.divider} />
+      <SimilarCollections similarCollections={similarCollections} />
     </div>
   );
 }

--- a/src/components/collection/Item.js
+++ b/src/components/collection/Item.js
@@ -86,18 +86,6 @@ export const Item = ({ item }) => {
 };
 
 Item.propTypes = {
-  classes: PropTypes.shape({
-    media: PropTypes.string.isRequired,
-    card: PropTypes.string.isRequired,
-    cardDescription: PropTypes.string.isRequired,
-    cardDescriptionText: PropTypes.string.isRequired,
-    expand: PropTypes.string.isRequired,
-    expandOpen: PropTypes.string.isRequired,
-  }).isRequired,
-  space: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }).isRequired,
   item: PropTypes.shape({
     image: PropTypes.string,
     description: PropTypes.string,

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -9,7 +10,6 @@ import CardActions from '@material-ui/core/CardActions';
 import Avatar from '@material-ui/core/Avatar';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
-import { red } from '@material-ui/core/colors';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -22,12 +22,10 @@ const useStyles = makeStyles(() => ({
   media: {
     paddingTop: '56.25%', // 16:9
   },
-  avatar: {
-    backgroundColor: red[500],
-  },
 }));
 
 export const SimilarCollection = ({ similarCollection }) => {
+  const { t } = useTranslation();
   const {
     name,
     image,
@@ -38,12 +36,12 @@ export const SimilarCollection = ({ similarCollection }) => {
     rating,
   } = similarCollection;
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [actionsMenuAnchor, setActionsMenuAnchor] = React.useState(null);
   const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
+    setActionsMenuAnchor(event.currentTarget);
   };
   const handleClose = () => {
-    setAnchorEl(null);
+    setActionsMenuAnchor(null);
   };
 
   const avatar = (
@@ -59,13 +57,13 @@ export const SimilarCollection = ({ similarCollection }) => {
       <MoreVertIcon onClick={handleClick} />
       <Menu
         id="actions-menu"
-        anchorEl={anchorEl}
+        anchorEl={actionsMenuAnchor}
         keepMounted
-        open={Boolean(anchorEl)}
+        open={Boolean(actionsMenuAnchor)}
         onClose={handleClose}
       >
-        <MenuItem onClick={handleClose}>Save Collection</MenuItem>
-        <MenuItem onClick={handleClose}>Copy link</MenuItem>
+        <MenuItem onClick={handleClose}>{t('Save Collection')}</MenuItem>
+        <MenuItem onClick={handleClose}>{t('Copy Link')}</MenuItem>
       </Menu>
     </IconButton>
   );
@@ -76,7 +74,7 @@ export const SimilarCollection = ({ similarCollection }) => {
         avatar={avatar}
         action={action}
         title={name}
-        subheader={`a collection by ${creator.name}`}
+        subheader={`${t('a collection by')} ${creator.name}`}
       />
       <CardMedia className={classes.media} image={image} title={name} />
       <CardContent>

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -73,15 +73,6 @@ export const SimilarCollection = ({ similarCollection }) => {
 };
 
 SimilarCollection.propTypes = {
-  classes: PropTypes.shape({
-    avatar: PropTypes.string.isRequired,
-    root: PropTypes.string.isRequired,
-    media: PropTypes.string.isRequired,
-  }).isRequired,
-  space: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }).isRequired,
   similarCollection: PropTypes.shape({
     name: PropTypes.string,
     image: PropTypes.string,

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -11,6 +11,8 @@ import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { red } from '@material-ui/core/colors';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
 import SimilarCollectionBadges from './SimilarCollectionBadges';
 
 const useStyles = makeStyles(() => ({
@@ -36,6 +38,13 @@ export const SimilarCollection = ({ similarCollection }) => {
     rating,
   } = similarCollection;
   const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   const avatar = (
     <Avatar
@@ -46,8 +55,18 @@ export const SimilarCollection = ({ similarCollection }) => {
   );
 
   const action = (
-    <IconButton aria-label="settings">
-      <MoreVertIcon />
+    <IconButton aria-label="actions">
+      <MoreVertIcon onClick={handleClick} />
+      <Menu
+        id="actions-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleClose}>Save Collection</MenuItem>
+        <MenuItem onClick={handleClose}>Copy link</MenuItem>
+      </Menu>
     </IconButton>
   );
 
@@ -81,8 +100,8 @@ SimilarCollection.propTypes = {
       name: PropTypes.string,
       avatar: PropTypes.string,
     }),
-    views: PropTypes.number,
     likes: PropTypes.number,
+    views: PropTypes.number,
     rating: PropTypes.shape({
       value: PropTypes.number,
       count: PropTypes.number,

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -1,39 +1,24 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import clsx from 'clsx';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';
 import CardActions from '@material-ui/core/CardActions';
-import Collapse from '@material-ui/core/Collapse';
 import Avatar from '@material-ui/core/Avatar';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { red } from '@material-ui/core/colors';
-import FavoriteIcon from '@material-ui/icons/Favorite';
-import ShareIcon from '@material-ui/icons/Share';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import SimilarCollectionBadges from './SimilarCollectionBadges';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 345,
   },
   media: {
-    height: 0,
     paddingTop: '56.25%', // 16:9
-  },
-  expand: {
-    transform: 'rotate(0deg)',
-    marginLeft: 'auto',
-    transition: theme.transitions.create('transform', {
-      duration: theme.transitions.duration.shortest,
-    }),
-  },
-  expandOpen: {
-    transform: 'rotate(180deg)',
   },
   avatar: {
     backgroundColor: red[500],
@@ -51,16 +36,17 @@ export const SimilarCollection = ({ similarCollection }) => {
     rating,
   } = similarCollection;
   const classes = useStyles();
-  const [expanded, setExpanded] = React.useState(false);
-
-  const handleExpandClick = () => {
-    setExpanded(!expanded);
-  };
 
   return (
     <Card className={classes.root}>
       <CardHeader
-        avatar={<Avatar aria-label="recipe" src={creator.avatar} />}
+        avatar={
+          <Avatar
+            aria-label={creator.name}
+            src={creator.avatar}
+            title={creator.name}
+          />
+        }
         action={
           <IconButton aria-label="settings">
             <MoreVertIcon />
@@ -69,7 +55,7 @@ export const SimilarCollection = ({ similarCollection }) => {
         title={name}
         subheader={`a collection by ${creator.name}`}
       />
-      <CardMedia className={classes.media} image={image} title="Paella dish" />
+      <CardMedia className={classes.media} image={image} title={name} />
       <CardContent>
         <Typography variant="body2" color="textSecondary" component="p">
           {description}
@@ -80,6 +66,33 @@ export const SimilarCollection = ({ similarCollection }) => {
       </CardActions>
     </Card>
   );
+};
+
+SimilarCollection.propTypes = {
+  classes: PropTypes.shape({
+    avatar: PropTypes.string.isRequired,
+    root: PropTypes.string.isRequired,
+    media: PropTypes.string.isRequired,
+  }).isRequired,
+  space: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  similarCollection: PropTypes.shape({
+    name: PropTypes.string,
+    image: PropTypes.string,
+    description: PropTypes.string,
+    creator: PropTypes.shape({
+      name: PropTypes.string,
+      avatar: PropTypes.string,
+    }),
+    views: PropTypes.number,
+    likes: PropTypes.number,
+    rating: PropTypes.shape({
+      value: PropTypes.number,
+      count: PropTypes.number,
+    }),
+  }).isRequired,
 };
 
 export default SimilarCollection;

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -37,21 +37,25 @@ export const SimilarCollection = ({ similarCollection }) => {
   } = similarCollection;
   const classes = useStyles();
 
+  const avatar = (
+    <Avatar
+      aria-label={creator.name}
+      src={creator.avatar}
+      title={creator.name}
+    />
+  );
+
+  const action = (
+    <IconButton aria-label="settings">
+      <MoreVertIcon />
+    </IconButton>
+  );
+
   return (
     <Card className={classes.root}>
       <CardHeader
-        avatar={
-          <Avatar
-            aria-label={creator.name}
-            src={creator.avatar}
-            title={creator.name}
-          />
-        }
-        action={
-          <IconButton aria-label="settings">
-            <MoreVertIcon />
-          </IconButton>
-        }
+        avatar={avatar}
+        action={action}
         title={name}
         subheader={`a collection by ${creator.name}`}
       />

--- a/src/components/collection/SimilarCollection.js
+++ b/src/components/collection/SimilarCollection.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardMedia from '@material-ui/core/CardMedia';
+import CardContent from '@material-ui/core/CardContent';
+import CardActions from '@material-ui/core/CardActions';
+import Collapse from '@material-ui/core/Collapse';
+import Avatar from '@material-ui/core/Avatar';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import { red } from '@material-ui/core/colors';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+import ShareIcon from '@material-ui/icons/Share';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import SimilarCollectionBadges from './SimilarCollectionBadges';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    maxWidth: 345,
+  },
+  media: {
+    height: 0,
+    paddingTop: '56.25%', // 16:9
+  },
+  expand: {
+    transform: 'rotate(0deg)',
+    marginLeft: 'auto',
+    transition: theme.transitions.create('transform', {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  expandOpen: {
+    transform: 'rotate(180deg)',
+  },
+  avatar: {
+    backgroundColor: red[500],
+  },
+}));
+
+export const SimilarCollection = ({ similarCollection }) => {
+  const {
+    name,
+    image,
+    description,
+    creator,
+    views,
+    likes,
+    rating,
+  } = similarCollection;
+  const classes = useStyles();
+  const [expanded, setExpanded] = React.useState(false);
+
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
+
+  return (
+    <Card className={classes.root}>
+      <CardHeader
+        avatar={<Avatar aria-label="recipe" src={creator.avatar} />}
+        action={
+          <IconButton aria-label="settings">
+            <MoreVertIcon />
+          </IconButton>
+        }
+        title={name}
+        subheader={`a collection by ${creator.name}`}
+      />
+      <CardMedia className={classes.media} image={image} title="Paella dish" />
+      <CardContent>
+        <Typography variant="body2" color="textSecondary" component="p">
+          {description}
+        </Typography>
+      </CardContent>
+      <CardActions disableSpacing>
+        <SimilarCollectionBadges views={views} likes={likes} rating={rating} />
+      </CardActions>
+    </Card>
+  );
+};
+
+export default SimilarCollection;

--- a/src/components/collection/SimilarCollectionBadges.js
+++ b/src/components/collection/SimilarCollectionBadges.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
-import {
-  Favorite,
-  Visibility,
-  Email,
-  Facebook,
-  Twitter,
-} from '@material-ui/icons';
+import { Favorite, Visibility } from '@material-ui/icons';
 import { Rating } from '@material-ui/lab';
 import PropTypes from 'prop-types';
-import { Grid, IconButton } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   badges: {

--- a/src/components/collection/SimilarCollectionBadges.js
+++ b/src/components/collection/SimilarCollectionBadges.js
@@ -51,8 +51,8 @@ function SimilarCollectionBadges({ views, likes, rating }) {
 }
 
 SimilarCollectionBadges.propTypes = {
-  views: PropTypes.number,
   likes: PropTypes.number,
+  views: PropTypes.number,
   rating: PropTypes.shape({
     count: PropTypes.number,
     value: PropTypes.number,

--- a/src/components/collection/SimilarCollectionBadges.js
+++ b/src/components/collection/SimilarCollectionBadges.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Badge from '@material-ui/core/Badge';
+import {
+  Favorite,
+  Visibility,
+  Email,
+  Facebook,
+  Twitter,
+} from '@material-ui/icons';
+import { Rating } from '@material-ui/lab';
+import PropTypes from 'prop-types';
+import { Grid, IconButton } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  badges: {
+    '& > *': {
+      marginRight: theme.spacing(3),
+    },
+  },
+  root: {
+    marginBottom: theme.spacing(),
+  },
+  cell: {
+    display: 'flex',
+  },
+}));
+
+function SimilarCollectionBadges({ views, likes, rating }) {
+  const classes = useStyles();
+
+  const { count, value } = rating;
+
+  return (
+    <Grid container className={classes.root}>
+      <Grid
+        item
+        xs={12}
+        className={classes.cell}
+        justify="flex-start"
+        alignItems="center"
+      >
+        <div className={classes.badges}>
+          <Badge badgeContent={count} color="secondary" max={999}>
+            <Rating value={value} />
+          </Badge>
+          <Badge badgeContent={likes} color="secondary" max={999}>
+            <Favorite color="primary" />
+          </Badge>
+          <Badge badgeContent={views} color="secondary" max={999}>
+            <Visibility color="primary" />
+          </Badge>
+        </div>
+      </Grid>
+    </Grid>
+  );
+}
+
+SimilarCollectionBadges.propTypes = {
+  views: PropTypes.number,
+  likes: PropTypes.number,
+  rating: PropTypes.shape({
+    count: PropTypes.number,
+    value: PropTypes.number,
+  }),
+};
+
+SimilarCollectionBadges.defaultProps = {
+  views: 0,
+  likes: 0,
+  rating: {
+    count: 0,
+    value: 0,
+  },
+};
+
+export default SimilarCollectionBadges;

--- a/src/components/collection/SimilarCollections.js
+++ b/src/components/collection/SimilarCollections.js
@@ -28,7 +28,7 @@ function SimilarCollections({ similarCollections }) {
       {!similarCollections.length ? (
         <div className="Main">
           <Typography variant="h5" color="inherit">
-            {t('This collection is empty.')}
+            {t('There are no similar collections available.')}
           </Typography>
         </div>
       ) : (
@@ -52,20 +52,20 @@ function SimilarCollections({ similarCollections }) {
   );
 }
 
-// Items.propTypes = {
-//   items: PropTypes.arrayOf(
-//     PropTypes.shape({
-//       image: PropTypes.string,
-//       description: PropTypes.string,
-//       viewLink: PropTypes.func,
-//       id: PropTypes.string,
-//       name: PropTypes.string,
-//     }),
-//   ),
-// };
+SimilarCollections.propTypes = {
+  similarCollections: PropTypes.arrayOf(
+    PropTypes.shape({
+      image: PropTypes.string,
+      description: PropTypes.string,
+      viewLink: PropTypes.func,
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  ),
+};
 
-// Items.defaultProps = {
-//   items: [],
-// };
+SimilarCollections.defaultProps = {
+  similarCollections: [],
+};
 
 export default SimilarCollections;

--- a/src/components/collection/SimilarCollections.js
+++ b/src/components/collection/SimilarCollections.js
@@ -55,11 +55,20 @@ function SimilarCollections({ similarCollections }) {
 SimilarCollections.propTypes = {
   similarCollections: PropTypes.arrayOf(
     PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
       image: PropTypes.string,
       description: PropTypes.string,
-      viewLink: PropTypes.func,
-      id: PropTypes.string,
-      name: PropTypes.string,
+      creator: PropTypes.shape({
+        name: PropTypes.string,
+        avatar: PropTypes.string,
+      }),
+      likes: PropTypes.number,
+      views: PropTypes.number,
+      rating: PropTypes.shape({
+        value: PropTypes.number,
+        count: PropTypes.number,
+      }),
     }),
   ),
 };

--- a/src/components/collection/SimilarCollections.js
+++ b/src/components/collection/SimilarCollections.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+import SimilarCollection from './SimilarCollection';
+import SimilarCollectionsHeader from './SimilarCollectionsHeader';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+  },
+  paper: {
+    padding: theme.spacing(2),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+}));
+
+function SimilarCollections({ similarCollections }) {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <SimilarCollectionsHeader />
+      {!similarCollections.length ? (
+        <div className="Main">
+          <Typography variant="h5" color="inherit">
+            {t('This collection is empty.')}
+          </Typography>
+        </div>
+      ) : (
+        <Grid container spacing={2}>
+          {similarCollections.map((similarCollection) => (
+            <Grid
+              key={similarCollection.id}
+              item
+              xs={12}
+              sm={4}
+              md={3}
+              lg={3}
+              xl={2}
+            >
+              <SimilarCollection similarCollection={similarCollection} />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+    </div>
+  );
+}
+
+// Items.propTypes = {
+//   items: PropTypes.arrayOf(
+//     PropTypes.shape({
+//       image: PropTypes.string,
+//       description: PropTypes.string,
+//       viewLink: PropTypes.func,
+//       id: PropTypes.string,
+//       name: PropTypes.string,
+//     }),
+//   ),
+// };
+
+// Items.defaultProps = {
+//   items: [],
+// };
+
+export default SimilarCollections;

--- a/src/components/collection/SimilarCollectionsHeader.js
+++ b/src/components/collection/SimilarCollectionsHeader.js
@@ -1,0 +1,50 @@
+import { Tooltip, Typography } from '@material-ui/core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Info } from '@material-ui/icons';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  cell: {
+    display: 'flex',
+  },
+  root: {
+    marginBottom: theme.spacing(2),
+    flexGrow: 1,
+  },
+}));
+
+function SimilarCollectionsHeader() {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <Grid container spacing={0}>
+        <Grid item xs={6} justify="flex-start">
+          <Typography
+            variant="h3"
+            color="inherit"
+            alignItems="center"
+            className={classes.cell}
+          >
+            {t('Similar Collections')}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          xs={6}
+          justify="flex-end"
+          alignItems="center"
+          className={classes.cell}
+        >
+          <Tooltip title={t('These are similar collections.')}>
+            <Info color="primary" />
+          </Tooltip>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+export default SimilarCollectionsHeader;

--- a/src/data/sample.js
+++ b/src/data/sample.js
@@ -149,8 +149,7 @@ export const comments = [
   },
 ];
 
-//Similar Collections
-
+// similar collections
 export const similarCollections = [
   {
     id: 1,

--- a/src/data/sample.js
+++ b/src/data/sample.js
@@ -148,3 +148,136 @@ export const comments = [
     date: '02 Apr 2020 20:31',
   },
 ];
+
+//Similar Collections
+
+export const similarCollections = [
+  {
+    id: 1,
+    name: 'Capitalism',
+    image:
+      'https://images.unsplash.com/photo-1516937941344-00b4e0337589?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80',
+    description:
+      'Capitalism is an economic system based on the private ownership of the means of production and their operation for profit. Characteristics central to capitalism include private property, capital accumulation, wage labor, voluntary exchange, a price system and competitive markets.',
+    creator: {
+      name: 'Ernie Brady',
+      avatar: 'https://api.adorable.io/avatars/130.png',
+    },
+    contributors: [
+      {
+        name: 'Cleopatra Snow',
+        avatar: 'https://api.adorable.io/avatars/66',
+      },
+      {
+        name: 'Ira Isabel',
+        avatar: 'https://api.adorable.io/avatars/177',
+      },
+      {
+        name: 'Maxim Eugene',
+        avatar: 'https://api.adorable.io/avatars/114',
+      },
+    ],
+    views: 29192,
+    likes: 55,
+    rating: {
+      value: 4,
+      count: 100,
+    },
+  },
+  {
+    id: 2,
+    name: 'The Anthropocene',
+    image:
+      'https://images.unsplash.com/photo-1528642474498-1af0c17fd8c3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80',
+    description:
+      "The Anthropocene is a geological epoch dating from the commencement of significant human impact on Earth's geology and ecosystems, including anthropogenic climate change. Various start dates for the Anthropocene have been proposed, ranging from 12,000–15,000 years ago to as recently as the 1960s.",
+    creator: {
+      name: 'Waverley Crosby',
+      avatar: 'https://api.adorable.io/avatars/156',
+    },
+    contributors: [
+      {
+        name: 'Brevin Dax',
+        avatar: 'https://api.adorable.io/avatars/45',
+      },
+      {
+        name: 'Zayne Paolo',
+        avatar: 'https://api.adorable.io/avatars/100',
+      },
+      {
+        name: 'Anthea Dixie',
+        avatar: 'https://api.adorable.io/avatars/22',
+      },
+    ],
+    views: 19019,
+    likes: 89,
+    rating: {
+      value: 5,
+      count: 157,
+    },
+  },
+  {
+    id: 3,
+    name: 'Fossil Fuels',
+    image:
+      'https://images.unsplash.com/photo-1546289917-e018604f4afa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80',
+    description:
+      'A fossil fuel is a fuel formed by natural processes, such as anaerobic decomposition of buried dead organisms, containing organic molecules originating in ancient photosynthesis that release energy in combustion. The burning of fossil fuels raises serious environmental concerns, due to its release of carbon dioxide (CO2).',
+    creator: {
+      name: 'Nanette Miriam',
+      avatar: 'https://api.adorable.io/avatars/310',
+    },
+    contributors: [
+      {
+        name: 'Elsa Jo',
+        avatar: 'https://api.adorable.io/avatars/212',
+      },
+      {
+        name: 'Quentin Wyatt',
+        avatar: 'https://api.adorable.io/avatars/223',
+      },
+      {
+        name: 'Vladimir Ulysses',
+        avatar: 'https://api.adorable.io/avatars/12',
+      },
+    ],
+    views: 10101,
+    likes: 67,
+    rating: {
+      value: 4,
+      count: 90,
+    },
+  },
+  {
+    id: 4,
+    name: 'Age of Enlightenment',
+    image:
+      'https://images.unsplash.com/photo-1521587760476-6c12a4b040da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80',
+    description:
+      'The Age of Enlightenment was an intellectual and philosophical movement that dominated the world of ideas in Europe during the 17th to 19th centuries. The Enlightenment included a range of ideas centered on the sovereignty of reason and the evidence of the senses as the primary sources of knowledge.',
+    creator: {
+      name: 'Emily Emmett',
+      avatar: 'https://api.adorable.io/avatars/114',
+    },
+    contributors: [
+      {
+        name: 'Aubreanna Alexis',
+        avatar: 'https://api.adorable.io/avatars/99',
+      },
+      {
+        name: 'Chanel Thompson',
+        avatar: 'https://api.adorable.io/avatars/250',
+      },
+      {
+        name: 'Kristoff Wolfgang',
+        avatar: 'https://api.adorable.io/avatars/33',
+      },
+    ],
+    views: 28912,
+    likes: 155,
+    rating: {
+      value: 5,
+      count: 240,
+    },
+  },
+];


### PR DESCRIPTION
I added dummy 'similar collection' data to src/data/sample, which I used in a new 'Similar Collections' section at the bottom of the main Graasp Explore Collections page. The 'Similar Collections' section I created follows the component pattern of other sections of the application (a SimilarCollections component which renders a SimilarCollectionsHeader and individual SimilarCollection components).

closes #7