### PR TITLE
44/images

### DIFF
--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
 import Home from './home/Home';
 import Collection from './collection/Collection';
 import Header from './layout/Header';
@@ -10,6 +11,7 @@ import { HEADER_HEIGHT } from '../config/constants';
 const useStyles = makeStyles(() => ({
   main: {
     paddingTop: HEADER_HEIGHT,
+    fontSize: '12w',
   },
   wrapper: {
     display: 'flex',
@@ -26,14 +28,16 @@ function App() {
       <Header />
       <div className={classes.wrapper}>
         <main className={classes.main}>
-          <Switch>
-            <Route path="/collections/:id">
-              <Collection />
-            </Route>
-            <Route path="/">
-              <Home />
-            </Route>
-          </Switch>
+          <Container maxWidth="lg">
+            <Switch>
+              <Route path="/collections/:id">
+                <Collection />
+              </Route>
+              <Route path="/">
+                <Home />
+              </Route>
+            </Switch>
+          </Container>
         </main>
         <Footer />
       </div>

--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -5,9 +5,18 @@ import Home from './home/Home';
 import Collection from './collection/Collection';
 import Header from './layout/Header';
 import Footer from './layout/Footer';
+import { HEADER_HEIGHT } from '../config/constants';
 
 const useStyles = makeStyles(() => ({
-  main: {},
+  main: {
+    paddingTop: HEADER_HEIGHT,
+  },
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    justifyContent: 'space-between',
+  },
 }));
 
 function App() {
@@ -15,17 +24,19 @@ function App() {
   return (
     <>
       <Header />
-      <main className={classes.main}>
-        <Switch>
-          <Route path="/collections/:id">
-            <Collection />
-          </Route>
-          <Route path="/">
-            <Home />
-          </Route>
-        </Switch>
-      </main>
-      <Footer />
+      <div className={classes.wrapper}>
+        <main className={classes.main}>
+          <Switch>
+            <Route path="/collections/:id">
+              <Collection />
+            </Route>
+            <Route path="/">
+              <Home />
+            </Route>
+          </Switch>
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/client/components/Root.js
+++ b/src/client/components/Root.js
@@ -46,7 +46,7 @@ let theme = createMuiTheme({
   typography: {
     useNextVariants: true,
     fontFamily: ['SuisseIntl', 'Helvetica', 'Arial', 'sans-serif'].join(','),
-    fontSize: 12,
+    fontSize: 14,
   },
 });
 

--- a/src/client/components/collection/Authorship.js
+++ b/src/client/components/collection/Authorship.js
@@ -66,12 +66,18 @@ function Authorship({ author, contributors }) {
 Authorship.propTypes = {
   author: PropTypes.shape({
     name: PropTypes.string,
-    image: PropTypes.shape({}),
+    image: PropTypes.shape({
+      gravatarUrl: PropTypes.string,
+      thumbnailUrl: PropTypes.string,
+    }),
   }).isRequired,
   contributors: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
-      image: PropTypes.shape({}),
+      image: PropTypes.shape({
+        gravatarUrl: PropTypes.string,
+        thumbnailUrl: PropTypes.string,
+      }),
     }),
   ),
 };

--- a/src/client/components/collection/Authorship.js
+++ b/src/client/components/collection/Authorship.js
@@ -10,6 +10,7 @@ import { getAvatar } from '../../utils/layout';
 const useStyles = makeStyles((theme) => ({
   root: {
     marginTop: theme.spacing(),
+    display: 'flex',
   },
   authorName: {
     marginLeft: theme.spacing(),
@@ -23,39 +24,42 @@ function Authorship({ author, contributors }) {
 
   const authorAvatar = getAvatar(image);
 
+  // the wrapper div is necessary for grid to apply
   return (
-    <Grid container className={classes.root}>
-      <Grid item xs={12} sm={6}>
-        <Typography variant="h5" gutterBottom>
-          {t('Author')}
-        </Typography>
-        <Grid container alignItems="center" justify="flex-start">
-          <Grid item>
-            <Avatar alt={authorName} src={authorAvatar} />
-          </Grid>
-          <Grid item className={classes.authorName}>
-            <Typography variant="body1">{authorName}</Typography>
-          </Grid>
-        </Grid>
-      </Grid>
-      {Boolean(contributors.length) && (
+    <div>
+      <Grid container>
         <Grid item xs={12} sm={6}>
           <Typography variant="h5" gutterBottom>
-            {t('Contributors')}
+            {t('Author')}
           </Typography>
-          <AvatarGroup max={8}>
-            {contributors.map((contributor) => {
-              const {
-                name: contributorName,
-                image: contributorAvatar,
-              } = contributor;
-              const avatar = getAvatar(contributorAvatar);
-              return <Avatar alt={contributorName} src={avatar} />;
-            })}
-          </AvatarGroup>
+          <Grid container alignItems="center" justify="flex-start">
+            <Grid item>
+              <Avatar alt={authorName} src={authorAvatar} />
+            </Grid>
+            <Grid item className={classes.authorName}>
+              <Typography variant="body1">{authorName}</Typography>
+            </Grid>
+          </Grid>
         </Grid>
-      )}
-    </Grid>
+        {Boolean(contributors.length) && (
+          <Grid item xs={12} sm={6}>
+            <Typography variant="h5" gutterBottom>
+              {t('Contributors')}
+            </Typography>
+            <AvatarGroup max={8}>
+              {contributors.map((contributor) => {
+                const {
+                  name: contributorName,
+                  image: contributorAvatar,
+                } = contributor;
+                const avatar = getAvatar(contributorAvatar);
+                return <Avatar alt={contributorName} src={avatar} />;
+              })}
+            </AvatarGroup>
+          </Grid>
+        )}
+      </Grid>
+    </div>
   );
 }
 

--- a/src/client/components/collection/Authorship.js
+++ b/src/client/components/collection/Authorship.js
@@ -24,8 +24,8 @@ function Authorship({ author, contributors }) {
 
   const authorAvatar = getAvatar(image);
 
-  // the wrapper div is necessary for grid to apply
   return (
+    // wrapper div is necessary for grid to apply
     <div>
       <Grid container>
         <Grid item xs={12} sm={6}>
@@ -66,12 +66,12 @@ function Authorship({ author, contributors }) {
 Authorship.propTypes = {
   author: PropTypes.shape({
     name: PropTypes.string,
-    image: PropTypes.string,
+    image: PropTypes.shape({}),
   }).isRequired,
   contributors: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
-      image: PropTypes.string,
+      image: PropTypes.shape({}),
     }),
   ),
 };

--- a/src/client/components/collection/Badges.js
+++ b/src/client/components/collection/Badges.js
@@ -66,14 +66,13 @@ function Badges({ views, likes, name, description }) {
   const mailString = `mailto:?subject=${subject}&body=${message}`;
 
   return (
-    <Grid container className={classes.root}>
-      <Grid
-        item
-        xs={6}
-        className={classes.cell}
-        justify="flex-start"
-        alignItems="center"
-      >
+    <Grid
+      container
+      justify="space-between"
+      alignItems="center"
+      className={classes.root}
+    >
+      <Grid item className={classes.cell}>
         <div className={classes.badges}>
           <Badge badgeContent={likes} color="secondary" max={999}>
             <Favorite color="primary" fontSize="large" />
@@ -83,13 +82,7 @@ function Badges({ views, likes, name, description }) {
           </Badge>
         </div>
       </Grid>
-      <Grid
-        item
-        xs={6}
-        className={classes.cell}
-        justify="flex-end"
-        alignItems="center"
-      >
+      <Grid item className={classes.cell}>
         <IconButton color="primary" onClick={shareOnFacebook}>
           <Facebook fontSize="large" />
         </IconButton>

--- a/src/client/components/collection/Collection.js
+++ b/src/client/components/collection/Collection.js
@@ -11,6 +11,7 @@ import { MEMBER_TYPES } from '../../config/constants';
 import Seo from '../common/Seo';
 import ITEM_DEFAULT_IMAGE from '../../resources/icon.png';
 import { removeTagsFromString } from '../../utils/text';
+import { buildImageUrl } from '../../utils/image';
 // todo: get similar collections in same call
 // import SimilarCollections from './SimilarCollections';
 
@@ -32,7 +33,7 @@ function Collection() {
       id,
       comments,
       description,
-      image,
+      image = {},
       subitems: items,
       voteScore: likes,
       name,
@@ -43,9 +44,11 @@ function Collection() {
     },
   } = useContext(CollectionContext);
 
+  const { pictureId } = image;
   const creator = members.find(({ type }) => type === MEMBER_TYPES.OWNER);
   const contributors = members.filter(({ id: mId }) => mId !== creator.id);
-  const imageUrl = image?.thumbnailUrl || ITEM_DEFAULT_IMAGE;
+  const imageUrl =
+    buildImageUrl({ id, pictureId, quality: 'large' }) || ITEM_DEFAULT_IMAGE;
 
   const classes = useStyles();
 

--- a/src/client/components/collection/Collection.js
+++ b/src/client/components/collection/Collection.js
@@ -7,7 +7,7 @@ import Summary from './Summary';
 import Items from './Items';
 import Comments from './Comments';
 import { CollectionContext } from '../CollectionProvider';
-import { MEMBER_TYPES } from '../../config/constants';
+import { DEFAULT_PICTURE_QUALITY, MEMBER_TYPES } from '../../config/constants';
 import Seo from '../common/Seo';
 import ITEM_DEFAULT_IMAGE from '../../resources/icon.png';
 import { removeTagsFromString } from '../../utils/text';
@@ -48,7 +48,8 @@ function Collection() {
   const creator = members.find(({ type }) => type === MEMBER_TYPES.OWNER);
   const contributors = members.filter(({ id: mId }) => mId !== creator.id);
   const imageUrl =
-    buildImageUrl({ id, pictureId, quality: 'large' }) || ITEM_DEFAULT_IMAGE;
+    buildImageUrl({ id, pictureId, quality: DEFAULT_PICTURE_QUALITY }) ||
+    ITEM_DEFAULT_IMAGE;
 
   const classes = useStyles();
 

--- a/src/client/components/collection/CollectionCard.js
+++ b/src/client/components/collection/CollectionCard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -20,20 +19,50 @@ import DEFAULT_COLLECTION_IMAGE from '../../resources/icon.png';
 import { getAvatar } from '../../utils/layout';
 import { buildCollectionRoute } from '../../config/routes';
 import { openInNewTab } from '../../config/helpers';
-import { CARD_DESCRITPION_MAX_LENGTH } from '../../config/constants';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     maxWidth: 345,
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-between',
   },
   media: {
     height: 300,
   },
-  header: {},
+  header: {
+    height: 60,
+    position: 'relative',
+  },
+  content: {
+    width: '65%',
+  },
+  title: {
+    overflow: 'hidden',
+    'text-overflow': 'ellipsis',
+    display: '-webkit-box',
+    '-webkit-line-clamp': '2' /* number of lines to show */,
+    '-webkit-box-orient': 'vertical',
+  },
+  actions: {
+    marginTop: 'auto',
+  },
+  subheader: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  },
+  description: {
+    margin: theme.spacing(1, 0),
+    overflow: 'hidden',
+    'text-overflow': 'ellipsis',
+    display: '-webkit-box',
+    '-webkit-line-clamp': '2' /* number of lines to show */,
+    '-webkit-box-orient': 'vertical',
+    '& p': {
+      margin: theme.spacing(0),
+    },
+  },
 }));
 
 export const CollectionCard = ({ collection = {} }) => {
@@ -70,8 +99,8 @@ export const CollectionCard = ({ collection = {} }) => {
   );
 
   const action = (
-    <IconButton aria-label="actions">
-      <MoreVertIcon onClick={handleClick} />
+    <IconButton aria-label="actions" onClick={handleClick}>
+      <MoreVertIcon />
       <Menu
         id="actions-menu"
         anchorEl={actionsMenuAnchor}
@@ -93,7 +122,13 @@ export const CollectionCard = ({ collection = {} }) => {
         avatar={avatar}
         action={action}
         title={name}
-        subheader={`${t('a collection by')} ${author.name}`}
+        subheader={author.name}
+        classes={{
+          root: classes.header,
+          title: classes.title,
+          subheader: classes.subheader,
+          content: classes.content,
+        }}
       />
       <CardActionArea onClick={handleCollectionClick}>
         <CardMedia
@@ -106,16 +141,14 @@ export const CollectionCard = ({ collection = {} }) => {
       <CardContent>
         <Typography variant="body2" color="textSecondary" component="p">
           <p
+            className={classes.description}
             dangerouslySetInnerHTML={{
-              __html: _.truncate(description, {
-                length: CARD_DESCRITPION_MAX_LENGTH,
-                separator: /,? +/,
-              }),
+              __html: description,
             }}
           />
         </Typography>
       </CardContent>
-      <CardActions disableSpacing>
+      <CardActions disableSpacing className={classes.actions}>
         <SimilarCollectionBadges views={views} voteScore={voteScore} />
       </CardActions>
     </Card>
@@ -126,7 +159,7 @@ CollectionCard.propTypes = {
   collection: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.string.isRequired,
-    image: PropTypes.string,
+    image: PropTypes.shape({}),
     description: PropTypes.string,
     author: PropTypes.shape({
       name: PropTypes.string,

--- a/src/client/components/collection/CollectionCard.js
+++ b/src/client/components/collection/CollectionCard.js
@@ -41,7 +41,8 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     'text-overflow': 'ellipsis',
     display: '-webkit-box',
-    '-webkit-line-clamp': '2' /* number of lines to show */,
+    // number of lines to show
+    '-webkit-line-clamp': '2',
     '-webkit-box-orient': 'vertical',
   },
   actions: {
@@ -57,7 +58,8 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     'text-overflow': 'ellipsis',
     display: '-webkit-box',
-    '-webkit-line-clamp': '2' /* number of lines to show */,
+    // number of lines to show
+    '-webkit-line-clamp': '2',
     '-webkit-box-orient': 'vertical',
     '& p': {
       margin: theme.spacing(0),
@@ -159,11 +161,17 @@ CollectionCard.propTypes = {
   collection: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.string.isRequired,
-    image: PropTypes.shape({}),
+    image: PropTypes.shape({
+      pictureId: PropTypes.string.isRequired,
+      thumbnailUrl: PropTypes.string,
+    }),
     description: PropTypes.string,
     author: PropTypes.shape({
       name: PropTypes.string,
-      image: PropTypes.shape({}),
+      image: PropTypes.shape({
+        gravatarUrl: PropTypes.string,
+        thumbnailUrl: PropTypes.string,
+      }),
     }),
     voteScore: PropTypes.number,
     views: PropTypes.number,

--- a/src/client/components/collection/CollectionCard.js
+++ b/src/client/components/collection/CollectionCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -19,14 +20,20 @@ import DEFAULT_COLLECTION_IMAGE from '../../resources/icon.png';
 import { getAvatar } from '../../utils/layout';
 import { buildCollectionRoute } from '../../config/routes';
 import { openInNewTab } from '../../config/helpers';
+import { CARD_DESCRITPION_MAX_LENGTH } from '../../config/constants';
 
 const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 345,
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
   },
   media: {
     height: 300,
   },
+  header: {},
 }));
 
 export const CollectionCard = ({ collection = {} }) => {
@@ -98,7 +105,14 @@ export const CollectionCard = ({ collection = {} }) => {
       </CardActionArea>
       <CardContent>
         <Typography variant="body2" color="textSecondary" component="p">
-          <p dangerouslySetInnerHTML={{ __html: description }} />
+          <p
+            dangerouslySetInnerHTML={{
+              __html: _.truncate(description, {
+                length: CARD_DESCRITPION_MAX_LENGTH,
+                separator: /,? +/,
+              }),
+            }}
+          />
         </Typography>
       </CardContent>
       <CardActions disableSpacing>

--- a/src/client/components/collection/CollectionsGrid.js
+++ b/src/client/components/collection/CollectionsGrid.js
@@ -5,12 +5,6 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import CollectionCard from './CollectionCard';
 
-// const useStyles = makeStyles(theme => ({
-//   cardLg: {
-
-//   }
-// }))
-
 function CollectionsGrid({ collections }) {
   const { t } = useTranslation();
 
@@ -22,7 +16,6 @@ function CollectionsGrid({ collections }) {
     <Grid container spacing={2} alignItems="stretch">
       {collections.map((similarCollection) => (
         <Grid
-          // className={{lg: classes.cardLg}}
           key={similarCollection.id}
           item
           xs={12}
@@ -41,9 +34,9 @@ function CollectionsGrid({ collections }) {
 CollectionsGrid.propTypes = {
   collections: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number,
+      id: PropTypes.string,
       name: PropTypes.string,
-      image: PropTypes.string,
+      image: PropTypes.shape({}),
       description: PropTypes.string,
       creator: PropTypes.shape({
         name: PropTypes.string,

--- a/src/client/components/collection/CollectionsGrid.js
+++ b/src/client/components/collection/CollectionsGrid.js
@@ -5,6 +5,12 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import CollectionCard from './CollectionCard';
 
+// const useStyles = makeStyles(theme => ({
+//   cardLg: {
+
+//   }
+// }))
+
 function CollectionsGrid({ collections }) {
   const { t } = useTranslation();
 
@@ -16,13 +22,14 @@ function CollectionsGrid({ collections }) {
     <Grid container spacing={2} alignItems="stretch">
       {collections.map((similarCollection) => (
         <Grid
+          // className={{lg: classes.cardLg}}
           key={similarCollection.id}
           item
           xs={12}
-          sm={4}
-          md={3}
+          sm={6}
+          md={4}
           lg={3}
-          xl={2}
+          xl={3}
         >
           <CollectionCard collection={similarCollection} />
         </Grid>

--- a/src/client/components/collection/CollectionsGrid.js
+++ b/src/client/components/collection/CollectionsGrid.js
@@ -36,7 +36,10 @@ CollectionsGrid.propTypes = {
     PropTypes.shape({
       id: PropTypes.string,
       name: PropTypes.string,
-      image: PropTypes.shape({}),
+      image: PropTypes.shape({
+        pictureId: PropTypes.string.isRequired,
+        thumbnailUrl: PropTypes.string,
+      }),
       description: PropTypes.string,
       creator: PropTypes.shape({
         name: PropTypes.string,

--- a/src/client/components/collection/CollectionsGrid.js
+++ b/src/client/components/collection/CollectionsGrid.js
@@ -13,7 +13,7 @@ function CollectionsGrid({ collections }) {
       {t('There are no collections available.')}
     </Typography>
   ) : (
-    <Grid container spacing={2}>
+    <Grid container spacing={2} alignItems="stretch">
       {collections.map((similarCollection) => (
         <Grid
           key={similarCollection.id}

--- a/src/client/components/collection/Comments.js
+++ b/src/client/components/collection/Comments.js
@@ -44,10 +44,7 @@ Comments.propTypes = {
   comments: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,
-      author: PropTypes.shape({
-        name: PropTypes.string,
-        avatar: PropTypes.string,
-      }),
+      author: PropTypes.string.isRequired,
       date: PropTypes.string,
     }),
   ),

--- a/src/client/components/collection/CommentsHeader.js
+++ b/src/client/components/collection/CommentsHeader.js
@@ -20,24 +20,13 @@ function CommentsHeader() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Grid container spacing={0}>
-        <Grid item xs={6} justify="flex-start">
-          <Typography
-            variant="h3"
-            color="inherit"
-            alignItems="center"
-            className={classes.cell}
-          >
+      <Grid container spacing={0} justify="space-between" alignItems="center">
+        <Grid item>
+          <Typography variant="h3" color="inherit" className={classes.cell}>
             {t('Comments')}
           </Typography>
         </Grid>
-        <Grid
-          item
-          xs={6}
-          justify="flex-end"
-          alignItems="center"
-          className={classes.cell}
-        >
+        <Grid item className={classes.cell}>
           <Tooltip title={t('These are the comments in this collection.')}>
             <Info color="primary" />
           </Tooltip>

--- a/src/client/components/collection/Item.js
+++ b/src/client/components/collection/Item.js
@@ -13,7 +13,7 @@ import IconButton from '@material-ui/core/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Text from '../common/Text';
 import ITEM_DEFAULT_IMAGE from '../../resources/icon.png';
-import { ITEM_TYPES } from '../../config/constants';
+import { DEFAULT_PICTURE_QUALITY, ITEM_TYPES } from '../../config/constants';
 import { openContentInNewTab, openInNewTab } from '../../config/helpers';
 import { buildSpaceViewerRoute } from '../../config/routes';
 import CopyButton from './CopyButton';
@@ -80,7 +80,8 @@ export const Item = ({ item }) => {
 
   const { pictureId } = image;
   const imageUrl =
-    buildImageUrl({ id, pictureId, quality: 'large' }) || ITEM_DEFAULT_IMAGE;
+    buildImageUrl({ id, pictureId, quality: DEFAULT_PICTURE_QUALITY }) ||
+    ITEM_DEFAULT_IMAGE;
 
   return (
     <Card id={id} className={classes.card}>

--- a/src/client/components/collection/Item.js
+++ b/src/client/components/collection/Item.js
@@ -17,6 +17,7 @@ import { ITEM_TYPES } from '../../config/constants';
 import { openContentInNewTab, openInNewTab } from '../../config/helpers';
 import { buildSpaceViewerRoute } from '../../config/routes';
 import CopyButton from './CopyButton';
+import { buildImageUrl } from '../../utils/image';
 
 const useStyles = makeStyles((theme) => ({
   card: {
@@ -48,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export const Item = ({ item }) => {
-  const { description, name, url, content, id, image, category } = item;
+  const { description, name, url, content, id, image = {}, category } = item;
   const classes = useStyles();
   const [expanded, setExpanded] = React.useState(false);
   const handleExpandClick = () => {
@@ -73,7 +74,9 @@ export const Item = ({ item }) => {
     }
   };
 
-  const imageUrl = image?.thumbnailUrl || ITEM_DEFAULT_IMAGE;
+  const { pictureId } = image;
+  const imageUrl =
+    buildImageUrl({ id, pictureId, quality: 'large' }) || ITEM_DEFAULT_IMAGE;
 
   return (
     <Card id={id} className={classes.card}>
@@ -120,6 +123,7 @@ export const Item = ({ item }) => {
 Item.propTypes = {
   item: PropTypes.shape({
     image: PropTypes.shape({
+      pictureId: PropTypes.number.isRequired,
       thumbnailUrl: PropTypes.string,
     }),
     description: PropTypes.string,

--- a/src/client/components/collection/Item.js
+++ b/src/client/components/collection/Item.js
@@ -127,7 +127,7 @@ export const Item = ({ item }) => {
 Item.propTypes = {
   item: PropTypes.shape({
     image: PropTypes.shape({
-      pictureId: PropTypes.number.isRequired,
+      pictureId: PropTypes.string.isRequired,
       thumbnailUrl: PropTypes.string,
     }),
     description: PropTypes.string,

--- a/src/client/components/collection/Item.js
+++ b/src/client/components/collection/Item.js
@@ -93,7 +93,7 @@ export const Item = ({ item }) => {
         />
 
         <CardContent>
-          <Typography variant="h5" component="h2" noWrap>
+          <Typography variant="h6" component="h2">
             {name}
           </Typography>
         </CardContent>

--- a/src/client/components/collection/Item.js
+++ b/src/client/components/collection/Item.js
@@ -22,6 +22,10 @@ import { buildImageUrl } from '../../utils/image';
 const useStyles = makeStyles((theme) => ({
   card: {
     width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
   },
   cardDescription: { margin: 0, paddingTop: 0, paddingBottom: 0 },
   cardDescriptionText: {

--- a/src/client/components/collection/Items.js
+++ b/src/client/components/collection/Items.js
@@ -47,7 +47,6 @@ function Items({ items }) {
 Items.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      image: PropTypes.string,
       description: PropTypes.string,
       viewLink: PropTypes.func,
       id: PropTypes.string,

--- a/src/client/components/collection/ItemsHeader.js
+++ b/src/client/components/collection/ItemsHeader.js
@@ -20,24 +20,13 @@ function ItemsHeader() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Grid container spacing={0}>
-        <Grid item xs={6} justify="flex-start">
-          <Typography
-            variant="h3"
-            color="inherit"
-            alignItems="center"
-            className={classes.cell}
-          >
+      <Grid container spacing={0} justify="space-between" alignItems="center">
+        <Grid item>
+          <Typography variant="h3" color="inherit" className={classes.cell}>
             {t('Items')}
           </Typography>
         </Grid>
-        <Grid
-          item
-          xs={6}
-          justify="flex-end"
-          alignItems="center"
-          className={classes.cell}
-        >
+        <Grid item className={classes.cell}>
           <Tooltip title={t('These are the items in this collection.')}>
             <Info color="primary" />
           </Tooltip>

--- a/src/client/components/collection/SimilarCollectionsHeader.js
+++ b/src/client/components/collection/SimilarCollectionsHeader.js
@@ -20,8 +20,8 @@ function SimilarCollectionsHeader() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Grid container spacing={0}>
-        <Grid item xs={6} justify="flex-start">
+      <Grid container spacing={0} justify="space-between">
+        <Grid item>
           <Typography
             variant="h3"
             color="inherit"
@@ -31,13 +31,7 @@ function SimilarCollectionsHeader() {
             {t('Similar Collections')}
           </Typography>
         </Grid>
-        <Grid
-          item
-          xs={6}
-          justify="flex-end"
-          alignItems="center"
-          className={classes.cell}
-        >
+        <Grid item alignItems="center" className={classes.cell}>
           <Tooltip title={t('These are similar collections.')}>
             <Info color="primary" />
           </Tooltip>

--- a/src/client/components/collection/Summary.js
+++ b/src/client/components/collection/Summary.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(2),
   },
   media: {
-    minHeight: 450,
+    minHeight: 350,
   },
   root: {
     flexGrow: 1,
@@ -38,18 +38,18 @@ function Summary({
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Grid container spacing={2}>
-        <Grid item sm={12} md={6} className={classes.centeredGridItem}>
+      <Grid container spacing={2} alignItems="flex-start">
+        <Grid item sm={12} md={4} className={classes.centeredGridItem}>
           <Card className={classes.card}>
             <CardMedia
               className={classes.media}
-              image={image?.thumbnailUrl || ITEM_DEFAULT_IMAGE}
+              image={image || ITEM_DEFAULT_IMAGE}
               title={name}
               component="img"
             />
           </Card>
         </Grid>
-        <Grid item sm={12} md={6}>
+        <Grid item sm={12} md={8}>
           <Typography variant="h1" gutterBottom>
             {name}
           </Typography>

--- a/src/client/components/collection/Summary.js
+++ b/src/client/components/collection/Summary.js
@@ -24,6 +24,9 @@ const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
   },
+  title: {
+    fontSize: '4em',
+  },
 }));
 
 function Summary({
@@ -50,7 +53,7 @@ function Summary({
           </Card>
         </Grid>
         <Grid item sm={12} md={8}>
-          <Typography variant="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom className={classes.title}>
             {name}
           </Typography>
           <Badges

--- a/src/client/components/collection/Summary.js
+++ b/src/client/components/collection/Summary.js
@@ -62,7 +62,7 @@ function Summary({
             likes={likes}
             description={description}
           />
-          <Typography variant="body1" gutterBottom component="p">
+          <Typography variant="body1" gutterBottom component="div">
             <div dangerouslySetInnerHTML={{ __html: description }} />
           </Typography>
           <Authorship author={creator} contributors={contributors} />

--- a/src/client/components/common/Seo.js
+++ b/src/client/components/common/Seo.js
@@ -4,13 +4,7 @@ import PropTypes from 'prop-types';
 import { APP_KEYWORDS, DEFAULT_LANG } from '../../config/constants';
 import ITEM_DEFAULT_IMAGE from '../../resources/icon.png';
 
-const Seo = ({
-  lang,
-  title,
-  description,
-  author,
-  image = ITEM_DEFAULT_IMAGE,
-}) => {
+const Seo = ({ lang, title, description, author, image }) => {
   const keywords = APP_KEYWORDS;
 
   // todo: default to env variable
@@ -48,11 +42,12 @@ const Seo = ({
 
 Seo.defaultProps = {
   lang: DEFAULT_LANG,
+  image: ITEM_DEFAULT_IMAGE,
 };
 
 Seo.propTypes = {
   lang: PropTypes.string,
-  image: PropTypes.string.isRequired,
+  image: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,

--- a/src/client/components/common/Seo.js
+++ b/src/client/components/common/Seo.js
@@ -52,14 +52,10 @@ Seo.defaultProps = {
 
 Seo.propTypes = {
   lang: PropTypes.string,
-  image: PropTypes.shape({
-    src: PropTypes.string.isRequired,
-    height: PropTypes.number.isRequired,
-    width: PropTypes.number.isRequired,
-  }).isRequired,
+  image: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  author: PropTypes.shape({ name: PropTypes.string.isRequired }).isRequired,
+  author: PropTypes.string.isRequired,
 };
 
 export default Seo;

--- a/src/client/components/home/Home.js
+++ b/src/client/components/home/Home.js
@@ -7,9 +7,9 @@ import CollectionsGrid from '../collection/CollectionsGrid';
 import { CollectionContext } from '../CollectionProvider';
 import Seo from '../common/Seo';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   wrapper: {
-    padding: theme.spacing(5),
+    padding: '4vw',
   },
 }));
 

--- a/src/client/components/layout/Footer.js
+++ b/src/client/components/layout/Footer.js
@@ -9,6 +9,12 @@ const useStyles = makeStyles(() => ({
     top: 'auto',
     bottom: 0,
   },
+  content: {
+    // fix: typography is strong on first render
+    '& strong': {
+      fontWeight: 400,
+    },
+  },
 }));
 
 function Footer() {
@@ -18,7 +24,9 @@ function Footer() {
     <footer>
       <AppBar position="static" color="primary" className={classes.appBar}>
         <Toolbar>
-          <Typography>© 2020 Graasp Association</Typography>
+          <Typography variant="subtitle1" className={classes.content}>
+            © 2020 Graasp Association
+          </Typography>
         </Toolbar>
       </AppBar>
     </footer>

--- a/src/client/components/layout/Footer.js
+++ b/src/client/components/layout/Footer.js
@@ -25,7 +25,8 @@ function Footer() {
       <AppBar position="static" color="primary" className={classes.appBar}>
         <Toolbar>
           <Typography variant="subtitle1" className={classes.content}>
-            {`© ${new Date().getFullYear()} Graasp Association`}
+            &copy;
+            {` ${new Date().getFullYear()} Graasp Association`}
           </Typography>
         </Toolbar>
       </AppBar>

--- a/src/client/components/layout/Footer.js
+++ b/src/client/components/layout/Footer.js
@@ -25,7 +25,7 @@ function Footer() {
       <AppBar position="static" color="primary" className={classes.appBar}>
         <Toolbar>
           <Typography variant="subtitle1" className={classes.content}>
-            © 2020 Graasp Association
+            {`© ${new Date().getFullYear()} Graasp Association`}
           </Typography>
         </Toolbar>
       </AppBar>

--- a/src/client/components/layout/Header.js
+++ b/src/client/components/layout/Header.js
@@ -30,7 +30,7 @@ function Header() {
 
   return (
     <header>
-      <AppBar position="static">
+      <AppBar position="absolute">
         <Toolbar>
           <a href={HOME_ROUTE} className={classes.link}>
             <Logo className={classes.logo} />

--- a/src/client/config/constants.js
+++ b/src/client/config/constants.js
@@ -42,3 +42,6 @@ export const TREE_VIEW_MIN_WIDTH = 350;
 
 export const TWITTER_MESSAGE_MAX_LENGTH = 270;
 export const MAIL_BREAK_LINE = '%0D%0A';
+
+export const CARD_DESCRITPION_MAX_LENGTH = 100;
+export const HEADER_HEIGHT = 65;

--- a/src/client/config/constants.js
+++ b/src/client/config/constants.js
@@ -43,5 +43,13 @@ export const TREE_VIEW_MIN_WIDTH = 350;
 export const TWITTER_MESSAGE_MAX_LENGTH = 270;
 export const MAIL_BREAK_LINE = '%0D%0A';
 
-export const CARD_DESCRITPION_MAX_LENGTH = 100;
 export const HEADER_HEIGHT = 65;
+
+// todo: use environment variables
+export const PICTURE_BASE_URL = 'https://graasp.eu';
+
+export const PICTURE_QUALITIES = {
+  LARGE: 'large',
+  MEDIUM: 'medium',
+};
+export const DEFAULT_PICTURE_QUALITY = PICTURE_QUALITIES.LARGE;

--- a/src/client/utils/image.js
+++ b/src/client/utils/image.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const buildImageUrl = ({ id, pictureId, quality = 'medium' }) =>
+  id && pictureId
+    ? `https://graasp.eu/pictures/${id}/${quality}_${pictureId}`
+    : null;

--- a/src/client/utils/image.js
+++ b/src/client/utils/image.js
@@ -1,5 +1,11 @@
+import { PICTURE_BASE_URL, PICTURE_QUALITIES } from '../config/constants';
+
 // eslint-disable-next-line import/prefer-default-export
-export const buildImageUrl = ({ id, pictureId, quality = 'medium' }) =>
+export const buildImageUrl = ({
+  id,
+  pictureId,
+  quality = PICTURE_QUALITIES.MEDIUM,
+}) =>
   id && pictureId
-    ? `https://graasp.eu/pictures/${id}/${quality}_${pictureId}`
+    ? `${PICTURE_BASE_URL}/pictures/${id}/${quality}_${pictureId}`
     : null;


### PR DESCRIPTION
Summary of the changes:

- use `large` images
- set footer at the bottom of the page
- bigger font (12 -> 14)
- gutters (I tried on zoomed in screen but you should check on a real big screen)
- smaller collection image (md-6 -> md-4)
- even height per row for cards (collection card and item card)
- truncate collection description in cards
- fix console errors
- show complete item name in cards

close #44 
close #43
close #42
close #41
close #26 
close #28

I did not deploy it so you can compare between the local and deploy version.