### PR TITLE
133/item metadata

### DIFF
--- a/src/components/collection/ChildrenCard.js
+++ b/src/components/collection/ChildrenCard.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
-import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
@@ -12,11 +11,10 @@ import IconButton from '@material-ui/core/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import CardMedia from '../common/CardMediaComponent';
 import Text from '../common/Text';
-import { openInNewTab } from '../../utils/helpers';
-import { buildPerformViewItemRoute } from '../../config/constants';
 import CopyButton from './CopyButton';
 import CopyLinkButton from './CopyLinkButton';
 import DownloadButton from './DownloadButton';
+import { buildCollectionRoute } from '../../config/routes';
 
 const useStyles = makeStyles((theme) => ({
   card: {
@@ -51,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const Item = ({ item }) => {
+export const ChildrenCard = ({ item }) => {
   const { description, name, id, extra } = item;
   const classes = useStyles();
   const [expanded, setExpanded] = React.useState(false);
@@ -59,21 +57,17 @@ export const Item = ({ item }) => {
     setExpanded(!expanded);
   };
 
-  const handleItemClick = () => {
-    openInNewTab(buildPerformViewItemRoute(id));
-  };
+  const link = buildCollectionRoute(id);
 
   return (
     <Card id={id} className={classes.card}>
-      <CardActionArea onClick={handleItemClick}>
-        <CardMedia itemId={id} name={name} />
+      <CardMedia itemId={id} name={name} link={link} />
 
-        <CardContent>
-          <Typography variant="h6" component="h2">
-            {name}
-          </Typography>
-        </CardContent>
-      </CardActionArea>
+      <CardContent>
+        <Typography variant="h6" component="h2">
+          {name}
+        </Typography>
+      </CardContent>
 
       <Collapse disableSpacing in={expanded} timeout="auto" unmountOnExit>
         <CardContent className={classes.cardDescription}>
@@ -102,7 +96,7 @@ export const Item = ({ item }) => {
   );
 };
 
-Item.propTypes = {
+ChildrenCard.propTypes = {
   item: PropTypes.shape({
     description: PropTypes.string,
     id: PropTypes.string,
@@ -112,4 +106,4 @@ Item.propTypes = {
   }).isRequired,
 };
 
-export default Item;
+export default ChildrenCard;

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -17,7 +17,7 @@ import {
 import { QueryClientContext } from '../QueryClientContext';
 import { PLACEHOLDER_COLLECTION } from '../../utils/collections';
 import {
-  buildPerformViewItemRoute,
+  buildPlayerViewItemRoute,
   DEFAULT_ITEM_IMAGE_PATH,
   ITEM_TYPES,
 } from '../../config/constants';
@@ -77,7 +77,7 @@ const Collection = ({ id }) => {
 
   const type = collection?.get('type');
   const handlePlay = () => {
-    openInNewTab(buildPerformViewItemRoute(id));
+    openInNewTab(buildPlayerViewItemRoute(id));
   };
 
   // todo: views don't exist
@@ -104,24 +104,23 @@ const Collection = ({ id }) => {
           isLoading={isLoading}
         />
         <Divider className={classes.divider} />
-        {type === ITEM_TYPES.FOLDER ? (
+        <Button
+          onClick={handlePlay}
+          variant="outlined"
+          size="large"
+          color="primary"
+          aria-label="play"
+          title={t('play')}
+          endIcon={<PlayCircleOutlineIcon />}
+          className={classes.playButton}
+        >
+          {t('View item in player')}
+        </Button>
+        {type === ITEM_TYPES.FOLDER && (
           <>
-            <Items parentId={id} />
             <Divider className={classes.divider} />
+            <Items parentId={id} />
           </>
-        ) : (
-          <Button
-            onClick={handlePlay}
-            variant="outlined"
-            size="large"
-            color="primary"
-            aria-label="play"
-            title={t('play')}
-            endIcon={<PlayCircleOutlineIcon />}
-            className={classes.playButton}
-          >
-            {t('View item in player')}
-          </Button>
         )}
         {/* <Comments comments={comments} members={members} /> */}
       </div>

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -33,6 +33,11 @@ const useStyles = makeStyles((theme) => ({
   divider: {
     margin: theme.spacing(2, 0),
   },
+  playButton: {
+    display: 'flex',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
 }));
 
 const Collection = ({ id }) => {
@@ -113,6 +118,7 @@ const Collection = ({ id }) => {
             aria-label="play"
             title={t('play')}
             endIcon={<PlayCircleOutlineIcon />}
+            className={classes.playButton}
           >
             {t('View item in player')}
           </Button>

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -2,7 +2,8 @@ import React, { useContext } from 'react';
 import { validate } from 'uuid';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import { Divider } from '@material-ui/core';
+import { Divider, IconButton } from '@material-ui/core';
+import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 import { ErrorBoundary } from '@sentry/react';
 import Error from '../common/Error';
 import Summary from './Summary';
@@ -14,7 +15,8 @@ import {
 } from '../../config/messages';
 import { QueryClientContext } from '../QueryClientContext';
 import { PLACEHOLDER_COLLECTION } from '../../utils/collections';
-import { DEFAULT_ITEM_IMAGE_PATH } from '../../config/constants';
+import { buildPerformViewItemRoute, DEFAULT_ITEM_IMAGE_PATH, ITEM_TYPES } from '../../config/constants';
+import { openInNewTab } from '../../utils/helpers';
 
 // todo: get similar collections in same call
 // import SimilarCollections from './SimilarCollections';
@@ -62,6 +64,11 @@ const Collection = ({ id }) => {
   const parsedDescription = collection?.get('description') || '';
   const settings = collection?.get('settings');
 
+  const type = collection?.get('type');
+  const handlePlay = () => {
+    openInNewTab(buildPerformViewItemRoute(id));
+  };
+
   // todo: views don't exist
   const views = collection?.get('views');
   const likes = likeCount;
@@ -86,7 +93,12 @@ const Collection = ({ id }) => {
           isLoading={isLoading}
         />
         <Divider className={classes.divider} />
-        <Items parentId={id} />
+        { type === ITEM_TYPES.FOLDER ? 
+          <Items parentId={id} /> : (
+            <IconButton onClick={handlePlay} aria-label="play">
+              <PlayCircleOutlineIcon />
+            </IconButton>
+        )}
         <Divider className={classes.divider} />
         {/* <Comments comments={comments} members={members} /> */}
       </div>

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -1,8 +1,9 @@
 import React, { useContext } from 'react';
 import { validate } from 'uuid';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
-import { Divider, IconButton } from '@material-ui/core';
+import { Divider, Button } from '@material-ui/core';
 import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 import { ErrorBoundary } from '@sentry/react';
 import Error from '../common/Error';
@@ -36,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
 
 const Collection = ({ id }) => {
   const classes = useStyles();
+  const { t } = useTranslation();
   const { hooks } = useContext(QueryClientContext);
   const {
     data: collection,
@@ -98,13 +100,23 @@ const Collection = ({ id }) => {
         />
         <Divider className={classes.divider} />
         {type === ITEM_TYPES.FOLDER ? (
-          <Items parentId={id} />
+          <>
+            <Items parentId={id} />
+            <Divider className={classes.divider} />
+          </>
         ) : (
-          <IconButton onClick={handlePlay} aria-label="play">
-            <PlayCircleOutlineIcon />
-          </IconButton>
+          <Button
+            onClick={handlePlay}
+            variant="outlined"
+            size="large"
+            color="primary"
+            aria-label="play"
+            title={t('play')}
+            endIcon={<PlayCircleOutlineIcon />}
+          >
+            {t('View item in player')}
+          </Button>
         )}
-        <Divider className={classes.divider} />
         {/* <Comments comments={comments} members={members} /> */}
       </div>
     </ErrorBoundary>

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -15,7 +15,11 @@ import {
 } from '../../config/messages';
 import { QueryClientContext } from '../QueryClientContext';
 import { PLACEHOLDER_COLLECTION } from '../../utils/collections';
-import { buildPerformViewItemRoute, DEFAULT_ITEM_IMAGE_PATH, ITEM_TYPES } from '../../config/constants';
+import {
+  buildPerformViewItemRoute,
+  DEFAULT_ITEM_IMAGE_PATH,
+  ITEM_TYPES,
+} from '../../config/constants';
 import { openInNewTab } from '../../utils/helpers';
 
 // todo: get similar collections in same call
@@ -93,11 +97,12 @@ const Collection = ({ id }) => {
           isLoading={isLoading}
         />
         <Divider className={classes.divider} />
-        { type === ITEM_TYPES.FOLDER ? 
-          <Items parentId={id} /> : (
-            <IconButton onClick={handlePlay} aria-label="play">
-              <PlayCircleOutlineIcon />
-            </IconButton>
+        {type === ITEM_TYPES.FOLDER ? (
+          <Items parentId={id} />
+        ) : (
+          <IconButton onClick={handlePlay} aria-label="play">
+            <PlayCircleOutlineIcon />
+          </IconButton>
         )}
         <Divider className={classes.divider} />
         {/* <Comments comments={comments} members={members} /> */}

--- a/src/components/collection/CollectionCard.js
+++ b/src/components/collection/CollectionCard.js
@@ -137,10 +137,7 @@ export const CollectionCard = ({ collection = {}, isLoading }) => {
     </>
   );
 
-  const link =
-    type === ITEM_TYPES.FOLDER
-      ? buildCollectionRoute(id)
-      : buildPeformViewEndpoint(id);
+  const link = buildCollectionRoute(id)
 
   return (
     <Card className={classes.root}>

--- a/src/components/collection/CollectionCard.js
+++ b/src/components/collection/CollectionCard.js
@@ -16,9 +16,8 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import SimilarCollectionBadges from './SimilarCollectionBadges';
 import { buildCollectionRoute } from '../../config/routes';
-import { DEFAULT_MEMBER_THUMBNAIL, ITEM_TYPES } from '../../config/constants';
+import { DEFAULT_MEMBER_THUMBNAIL } from '../../config/constants';
 import { QueryClientContext } from '../QueryClientContext';
-import { buildPeformViewEndpoint } from '../../api/endpoints';
 import CopyButton from './CopyButton';
 import CardMedia from '../common/CardMediaComponent';
 import CopyLinkButton from './CopyLinkButton';
@@ -78,7 +77,7 @@ const useStyles = makeStyles((theme) => ({
 
 export const CollectionCard = ({ collection = {}, isLoading }) => {
   const { t } = useTranslation();
-  const { name, id, description, creator, views, voteScore, type, extra } =
+  const { name, id, description, creator, views, voteScore, extra } =
     collection;
   const classes = useStyles();
   const [actionsMenuAnchor, setActionsMenuAnchor] = React.useState(null);
@@ -137,7 +136,7 @@ export const CollectionCard = ({ collection = {}, isLoading }) => {
     </>
   );
 
-  const link = buildCollectionRoute(id)
+  const link = buildCollectionRoute(id);
 
   return (
     <Card className={classes.root}>

--- a/src/components/collection/Items.js
+++ b/src/components/collection/Items.js
@@ -5,7 +5,7 @@ import { List } from 'immutable';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
-import Item from './Item';
+import { ChildrenCard } from './ChildrenCard';
 import ItemsHeader from './ItemsHeader';
 import { QueryClientContext } from '../QueryClientContext';
 import { PLACEHOLDER_COLLECTION } from '../../utils/collections';
@@ -43,7 +43,7 @@ function Items({ parentId }) {
         <Grid container spacing={2} id={CHILDREN_ITEMS_GRID_ID}>
           {items.map((item) => (
             <Grid key={item.id} item xs={12} sm={4} md={3} lg={3} xl={2}>
-              <Item item={item} />
+              <ChildrenCard item={item} />
             </Grid>
           ))}
         </Grid>

--- a/src/components/common/Wrapper.js
+++ b/src/components/common/Wrapper.js
@@ -17,6 +17,8 @@ const useStyles = makeStyles((theme) => ({
   },
   divider: {
     marginTop: theme.spacing(10),
+    // divider for placeholder at bottom to prevent item be covered by footer, set color to white
+    backgroundColor: '#FFF',
   },
 }));
 

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -83,7 +83,7 @@ function Home() {
       (collection) => collection.creator === NEXT_PUBLIC_GRAASPER_ID,
     );
 
-    if (collectionsGraasper?.isEmpty()) {
+    if (!collectionsGraasper || collectionsGraasper.isEmpty()) {
       return null;
     }
 

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -83,7 +83,7 @@ function Home() {
       (collection) => collection.creator === NEXT_PUBLIC_GRAASPER_ID,
     );
 
-    if (collectionsGraasper.isEmpty()) {
+    if (collectionsGraasper?.isEmpty()) {
       return null;
     }
 

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -92,5 +92,5 @@ export const DEFAULT_THUMBNAIL_SIZE = THUMBNAIL_SIZES.MEDIUM;
 export const SIGN_IN_ROUTE = `${GRAASP_AUTH_HOST}/signIn`;
 export const SIGN_UP_ROUTE = `${GRAASP_AUTH_HOST}/signUp`;
 
-export const buildPerformViewItemRoute = (id = ':id') =>
+export const buildPlayerViewItemRoute = (id = ':id') =>
   `${GRAASP_PERFORM_HOST}/${id}`;

--- a/src/config/notifier.js
+++ b/src/config/notifier.js
@@ -3,7 +3,7 @@ import { routines } from '@graasp/query-client';
 import { toast } from 'react-toastify';
 import i18n from './i18n';
 import ToastrWithLink from '../components/common/ToastrWithLink';
-import { buildPerformViewItemRoute } from './constants';
+import { buildPlayerViewItemRoute } from './constants';
 
 export const COPY_RESOURCE_LINK_TO_CLIPBOARD = {
   SUCESS: 'success',
@@ -19,7 +19,7 @@ const notifier = ({ type, payload }) => {
     case routines.copyItemRoutine.SUCCESS:
       toast.success(
         <ToastrWithLink
-          link={buildPerformViewItemRoute(payload.id)}
+          link={buildPlayerViewItemRoute(payload.id)}
           text={i18n.t('The item was copied successfully')}
           linkText={i18n.t('Click here to open the item on Graasp.')}
         />,


### PR DESCRIPTION
close #133 

This PR mainly add an extra layer to non-folder item, to display its metadata, instead of open it in player directly.
I change `Item` to `ChildrenCard`, which is similar to `CollectionCard`, while with `Collection`, depends on it's type, it displays children items, or just display a play button to switch to player.
We can further discuss @pyphilia 